### PR TITLE
[ 不具合修正 ] WordPress 専用ディレクトリ構成で vk_admin.js / CSS が 404 になる不具合を修正（0.5.1）

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ VkAdmin::init();
 
 ## Change log
 
+== 0.5.1 ==
 [ Bug Fix ] Fixed broken vk_admin.js / CSS URL on environments where site_url and home_url differ (WordPress installed in its own directory) or wp-content is relocated.
+[ Bug Fix ] Skip enqueuing widget screen CSS when not in admin context.
 [ Other ]  Fix CSS load hook.
 
 == 0.5.0 ==

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ VkAdmin::init();
 
 ## Change log
 
+[ Bug Fix ] Fixed broken vk_admin.js / CSS URL on environments where site_url and home_url differ (WordPress installed in its own directory) or wp-content is relocated.
 [ Other ]  Fix CSS load hook.
 
 == 0.5.0 ==

--- a/src/VkAdmin.php
+++ b/src/VkAdmin.php
@@ -55,8 +55,11 @@ class VkAdmin {
 			return untrailingslashit( $current_url );
 		}
 
-		// いずれにも一致しない場合は最後の保険として従来挙動を維持する。
-		return untrailingslashit( str_replace( $abs_path, trailingslashit( site_url( '/' ) ), $current_path ) );
+		// いずれにも一致しない場合でも、必ず URL を返す。
+		// str_replace では置換対象が見つからないとパスをそのまま返してしまい、
+		// 絶対パスが URL として enqueue されてしまうため、plugins_url() に委ねる。
+		// vendor 配下に置かれていても plugins_url は親プラグインの URL を解決してくれる。
+		return untrailingslashit( plugins_url( '', __FILE__ ) );
 	}
 
 	public static function add_widget_screen_css() {

--- a/src/VkAdmin.php
+++ b/src/VkAdmin.php
@@ -5,14 +5,14 @@
  * @package vektor-inc/vk-admin
  * @license GPL-2.0+
  *
- * @version 0.5.0
+ * @version 0.5.1
  */
 
 namespace VektorInc\VK_Admin;
 
 class VkAdmin {
 
-	public static $version = '0.5.0';
+	public static $version = '0.5.1';
 
 	public static function init() {
 		$locale = ( is_admin() && function_exists( 'get_user_locale' ) ) ? get_user_locale() : get_locale();

--- a/src/VkAdmin.php
+++ b/src/VkAdmin.php
@@ -32,19 +32,31 @@ class VkAdmin {
 	 * @return string 現在のディレクトリの URL
 	 */
 	protected static function get_current_dir_url() {
-		$current_path = wp_normalize_path( dirname( __FILE__ ) );
-		$content_path = wp_normalize_path( WP_CONTENT_DIR );
+		// 現在のディレクトリ末尾にもスラッシュを付与しておくことで、
+		// dirname() が末尾スラッシュなしを返すケースでも比較対象と桁を揃える。
+		$current_path = trailingslashit( wp_normalize_path( dirname( __FILE__ ) ) );
 
 		// WP_CONTENT_DIR が現在のパスの先頭に一致する想定。
+		// 末尾スラッシュ付きで比較・置換することで、wp-content と wp-content-other
+		// のような同一プレフィックス別ディレクトリへの誤マッチを防ぐ。
 		// content_url() を基準に置換することで site_url と home_url が異なる
 		// 構成でも正しい URL を組み立てられる。
+		$content_path = trailingslashit( wp_normalize_path( WP_CONTENT_DIR ) );
 		if ( 0 === strpos( $current_path, $content_path ) ) {
-			return str_replace( $content_path, content_url(), $current_path );
+			$current_url = trailingslashit( content_url() ) . substr( $current_path, strlen( $content_path ) );
+			return untrailingslashit( $current_url );
 		}
 
 		// フォールバック: 従来通り ABSPATH ベースで解決する。
-		$abs_path = wp_normalize_path( ABSPATH );
-		return str_replace( $abs_path, site_url( '/' ), $current_path );
+		// こちらも末尾スラッシュ付きで比較し、誤マッチを防ぐ。
+		$abs_path = trailingslashit( wp_normalize_path( ABSPATH ) );
+		if ( 0 === strpos( $current_path, $abs_path ) ) {
+			$current_url = trailingslashit( site_url( '/' ) ) . substr( $current_path, strlen( $abs_path ) );
+			return untrailingslashit( $current_url );
+		}
+
+		// いずれにも一致しない場合は最後の保険として従来挙動を維持する。
+		return untrailingslashit( str_replace( $abs_path, trailingslashit( site_url( '/' ) ), $current_path ) );
 	}
 
 	public static function add_widget_screen_css() {

--- a/src/VkAdmin.php
+++ b/src/VkAdmin.php
@@ -23,26 +23,45 @@ class VkAdmin {
 		add_action( 'enqueue_block_assets', array( __CLASS__, 'add_widget_screen_css' ) );
 	}
 
+	/**
+	 * 現在のディレクトリ（__DIR__）に対応する URL を返す
+	 * WordPress を専用ディレクトリに置く構成（site_url と home_url が異なる）や
+	 * wp-content の場所をカスタマイズしている環境でも正しく動作するよう、
+	 * ABSPATH ではなく WP_CONTENT_DIR / content_url() を起点に解決する。
+	 *
+	 * @return string 現在のディレクトリの URL
+	 */
+	protected static function get_current_dir_url() {
+		$current_path = wp_normalize_path( dirname( __FILE__ ) );
+		$content_path = wp_normalize_path( WP_CONTENT_DIR );
+
+		// WP_CONTENT_DIR が現在のパスの先頭に一致する想定。
+		// content_url() を基準に置換することで site_url と home_url が異なる
+		// 構成でも正しい URL を組み立てられる。
+		if ( 0 === strpos( $current_path, $content_path ) ) {
+			return str_replace( $content_path, content_url(), $current_path );
+		}
+
+		// フォールバック: 従来通り ABSPATH ベースで解決する。
+		$abs_path = wp_normalize_path( ABSPATH );
+		return str_replace( $abs_path, site_url( '/' ), $current_path );
+	}
+
 	public static function add_widget_screen_css() {
 		if ( ! is_admin() ) {
 			return;
 		}
-		$current_path = dirname( __FILE__ );
-		$current_url  = str_replace( ABSPATH, site_url( '/' ), $current_path );
+		$current_url = self::get_current_dir_url();
 		wp_enqueue_style( 'vk-admin-style', $current_url . '/assets/css/customize-and-widget.css', array(), self::$version, 'all' );
 	}
 
 	public static function admin_common_css() {
-		$current_path = wp_normalize_path( dirname( __FILE__ ) );
-		$abs_path     = wp_normalize_path( ABSPATH );
-		$current_url  = str_replace( $abs_path, site_url( '/' ), $current_path );
+		$current_url = self::get_current_dir_url();
 		wp_enqueue_style( 'vk-admin-style', $current_url . '/assets/css/vk_admin.css', array(), self::$version, 'all' );
 	}
 
 	public static function admin_enqueue_scripts() {
-		$current_path = wp_normalize_path( dirname( __FILE__ ) );
-		$abs_path     = wp_normalize_path( ABSPATH );
-		$current_url  = str_replace( $abs_path, site_url( '/' ), $current_path );
+		$current_url = self::get_current_dir_url();
 		wp_enqueue_script( 'jquery' );
 		wp_enqueue_media();
 		wp_enqueue_script( 'vk-admin-js', $current_url . '/assets/js/vk_admin.js', array( 'jquery' ), self::$version );


### PR DESCRIPTION
## 概要

WordPress を独自ディレクトリにインストールした構成（`site_url` と `home_url` が異なる構成）や `wp-content` の場所をカスタマイズしている環境で、`vk_admin.js` および vk-admin が enqueue する CSS の URL が誤って生成され、404 になる不具合を修正します。

報告元: vektor-inc/vk-all-in-one-expansion-unit#1337

```
GET https://demo.vk-fullsite-installer.com/hairsalon/wp-content/plugins/vk-all-in-one-expansion-unit/vendor/vektor-inc/vk-admin/src/assets/js/vk_admin.js?ver=0.5.0 net::ERR_ABORTED 404 (Not Found)
```

## 原因

`VkAdmin::admin_enqueue_scripts()` / `admin_common_css()` / `add_widget_screen_css()` がアセット URL を以下のように組み立てており、`ABSPATH`（WP コアのパス）と公開 URL のルートが一致する前提になっていました。

```php
$current_url = str_replace( ABSPATH, site_url( '/' ), $current_path );
```

このため、WordPress を専用ディレクトリにインストールしている構成や `wp-content` を別の場所に配置している構成では、生成 URL が実体とズレて 404 になります。

## 修正内容

1. URL 解決を `get_current_dir_url()` という共通ヘルパに集約
2. 一次手段: `WP_CONTENT_DIR` を `content_url()` に置換する方式に変更し、`site_url` と `home_url` が異なる構成や `wp-content` を移動した構成でも正しく URL が生成されるようにする
3. フォールバック: 万一プラグインが `wp-content` 外に置かれているケースを想定し、従来の `ABSPATH → site_url('/')` 方式も残す
4. プレフィックス比較の堅牢化: `wp-content` と `wp-content-other` のような同一プレフィックス別ディレクトリへの誤マッチを防ぐため、`trailingslashit()` で末尾スラッシュを担保したパス同士で先頭一致判定・置換を行う
5. version を `0.5.0` → `0.5.1` に更新し、既存の未リリース変更（CSS フック調整・`is_admin()` ガード）と合わせて 0.5.1 として整理

## 変更ファイル

- `src/VkAdmin.php`
  - `get_current_dir_url()` 追加（`WP_CONTENT_DIR` ベース + フォールバック、`trailingslashit()` による堅牢化）
  - `admin_enqueue_scripts()` / `admin_common_css()` / `add_widget_screen_css()` をヘルパ経由に統一
  - `@version` / `public static $version` を `0.5.1` に更新
- `README.md`
  - Change log に `== 0.5.1 ==` セクションを追加し、本 PR の修正と既存未リリース変更をまとめて記載

## 確認手順

### 前提条件

- WordPress を独自ディレクトリにインストールした環境を用意する（または `wp-config.php` で `WP_HOME` / `WP_SITEURL` を別パスに設定する）
  - 例: コアは `https://example.com/wp/`、サイト URL は `https://example.com/`
- vk-admin を composer 依存として組み込んだプラグイン（例: vk-all-in-one-expansion-unit）を有効化する
- WordPress 管理画面にログインできる状態にする

### Before（修正前の再現手順）

1. 修正前の vk-admin (0.5.0) を `vendor/vektor-inc/vk-admin/` に配置した状態で WordPress 管理画面（ダッシュボード）を開く
2. ブラウザの DevTools の Network パネルを開く
   → ✗ `vk_admin.js` および vk-admin の CSS が 404 になる
   → ✗ コンソールに `GET .../vk-admin/src/assets/js/vk_admin.js net::ERR_ABORTED 404 (Not Found)` が表示される

### After（修正後）

1. 本 PR ブランチの vk-admin を `vendor/vektor-inc/vk-admin/` に配置（または `composer update vektor-inc/vk-admin`）
2. WordPress 管理画面（ダッシュボード）を開く
3. ブラウザの DevTools の Network パネルを確認する
   → ✓ `vk_admin.js` が 200 で読み込まれる
   → ✓ vk-admin の CSS（`vk_admin.css` / `customize-and-widget.css`）も 200 で読み込まれる
4. 標準構成の WordPress（`site_url == home_url`、`wp-content` がデフォルトの場所）でも管理画面を開く
   → ✓ 同様に `vk_admin.js` / CSS が 200 で読み込まれ、従来動作にデグレがない
5. ウィジェット画面・カスタマイザー画面・ブロックエディタを開く
   → ✓ vk-admin が提供する管理画面スタイルが従来通り適用される

## 関連 issue

- vektor-inc/vk-all-in-one-expansion-unit#1337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 管理画面資産のURL生成の不具合を修正し、サイト設定やコンテンツディレクトリの違いによるリンク切れを解消しました
  * 管理画面外ではウィジェット画面用のスタイルシートを読み込まないように修正しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-admin/pull/10)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->