### PR TITLE
[ 機能追加 ] VK_Custom_Html_Control と VK_Custom_Text_Control を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,59 @@ use VektorInc\VK_Admin\VkAdmin;
 VkAdmin::init();
 ```
 
+## カスタマイザー用 独自 control
+
+このパッケージには、カスタマイザーで使える独自 control クラスが同梱されています。
+`composer require vektor-inc/vk-admin` した上で `vendor/autoload.php` を読み込めば、
+グローバル名前空間にクラスが定義されているため、そのまま `new` して利用できます。
+
+### VK_Custom_Html_Control
+
+ラベル・サブタイトル・任意 HTML をまとめて出力するための control。
+カスタマイザーのセクション内に説明文や注意書きを表示したいときに利用します。
+
+```php
+$wp_customize->add_control(
+    new VK_Custom_Html_Control(
+        $wp_customize,
+        'your_setting_description',
+        array(
+            'section'          => 'your_section',
+            'label'            => __( 'Section Title', 'your-textdomain' ),
+            'custom_title_sub' => __( 'Sub Title', 'your-textdomain' ),
+            'custom_html'      => '<p>' . esc_html__( '説明文', 'your-textdomain' ) . '</p>',
+        )
+    )
+);
+```
+
+### VK_Custom_Text_Control
+
+text 入力欄の前後に補助文字列（例: 単位ラベル）を、入力欄の下に共通 description を
+表示するための control。同じセクションで `width` / `height` のように複数の control に
+同じ説明文を持たせたい場合の集約用にも使えます。
+
+```php
+$wp_customize->add_control(
+    new VK_Custom_Text_Control(
+        $wp_customize,
+        'your_setting_width',
+        array(
+            'section'     => 'your_section',
+            'label'       => __( 'Width', 'your-textdomain' ),
+            'description' => __( '幅と高さを揃えたい場合は両方指定してください。', 'your-textdomain' ),
+            'input_after' => 'px',
+        )
+    )
+);
+```
+
 
 ---
 
 ## Change log
+
+[ Feature Add ] Add VK_Custom_Html_Control and VK_Custom_Text_Control as shared customizer controls for reuse across plugins.
 
 == 0.5.1 ==
 [ Bug Fix ] Fixed broken vk_admin.js / CSS URL on environments where site_url and home_url differ (WordPress installed in its own directory) or wp-content is relocated.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Composer の require に登録
 composer require vektor-inc/vk-admin
 ```
 
-autoload.pho を読み込み
+autoload.php を読み込み
 ```
 require_once dirname( __FILE__ ) . '/vendor/autoload.php';
 ```

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,11 @@
 	"autoload": {
 		"psr-4": {
 			"VektorInc\\VK_Admin\\": "src/"
-		}
+		},
+		"files": [
+			"src/VK_Custom_Html_Control.php",
+			"src/VK_Custom_Text_Control.php"
+		]
 	},
 	"authors": [
 		{

--- a/src/VK_Custom_Html_Control.php
+++ b/src/VK_Custom_Html_Control.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * VK Custom HTML Control
+ *
+ * カスタマイザーで任意の HTML（説明文・補助情報など）を出力するための独自 control。
+ * Previously each plugin (Lightning G3 Pro Unit, ExUnit, etc.) defined this class
+ * locally with a `class_exists()` guard. This file consolidates that definition
+ * inside the shared vk-admin package so plugins can rely on a single source of
+ * truth instead of copy/pasting the class.
+ *
+ * @package vektor-inc/vk-admin
+ * @license GPL-2.0+
+ */
+
+// グローバル名前空間（namespace 宣言なし）。
+// 既存プラグインが `new VK_Custom_Html_Control(...)` で利用しているため、
+// クラス名はグローバルのまま維持する必要がある。
+
+// WP_Customize_Control が存在しない環境（フロント側など）では本クラスを宣言しない。
+if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'VK_Custom_Html_Control' ) ) {
+
+	/**
+	 * VK_Custom_Html_Control
+	 *
+	 * WP_Customize_Control を継承し、ラベル・サブタイトル・任意 HTML をまとめて
+	 * 出力するための control。設定値そのものではなく説明文や注意書きを
+	 * カスタマイザーのセクション内に表示する用途で利用する。
+	 *
+	 * 公開プロパティ:
+	 *  - $type             : control の type 識別子（'customtext'）。
+	 *  - $custom_title_sub : ラベルの直下に表示するサブタイトル（h3）。
+	 *  - $custom_html      : サブタイトルの下に表示する任意 HTML（wp_kses_post でエスケープ）。
+	 *
+	 * 利用例:
+	 *  $wp_customize->add_control(
+	 *      new VK_Custom_Html_Control(
+	 *          $wp_customize,
+	 *          'vk_admin_sample_description',
+	 *          array(
+	 *              'section'          => 'vk_admin_sample_section',
+	 *              'label'            => __( 'Section Title', 'your-textdomain' ),
+	 *              'custom_title_sub' => __( 'Sub Title', 'your-textdomain' ),
+	 *              'custom_html'      => '<p>' . esc_html__( '説明文', 'your-textdomain' ) . '</p>',
+	 *          )
+	 *      )
+	 *  );
+	 */
+	class VK_Custom_Html_Control extends WP_Customize_Control {
+
+		/**
+		 * Control type.
+		 *
+		 * WP_Customize_Control が内部で参照する type 識別子。
+		 *
+		 * @var string
+		 */
+		public $type = 'customtext';
+
+		/**
+		 * Sub title shown under the main label.
+		 *
+		 * label の直下に h3 として表示するサブタイトル。
+		 *
+		 * @var string
+		 */
+		public $custom_title_sub = '';
+
+		/**
+		 * Arbitrary HTML displayed below the sub title.
+		 *
+		 * 任意 HTML。wp_kses_post() で出力時にサニタイズされる。
+		 *
+		 * @var string
+		 */
+		public $custom_html = '';
+
+		/**
+		 * Render the control's content.
+		 *
+		 * ラベル → サブタイトル → 任意 HTML の順で出力する。
+		 * いずれも未設定の場合は何も出力しない。
+		 *
+		 * @return void
+		 */
+		public function render_content() {
+			// ラベルが設定されていれば h2 として出力する。
+			if ( $this->label ) {
+				echo '<h2 class="admin-custom-h2">' . wp_kses_post( $this->label ) . '</h2>';
+			}
+			// サブタイトルが設定されていれば h3 として出力する。
+			if ( $this->custom_title_sub ) {
+				echo '<h3 class="admin-custom-h3">' . wp_kses_post( $this->custom_title_sub ) . '</h3>';
+			}
+			// 任意 HTML が設定されていれば div でラップして出力する。
+			if ( $this->custom_html ) {
+				echo '<div>' . wp_kses_post( $this->custom_html ) . '</div>';
+			}
+		}
+	}
+}

--- a/src/VK_Custom_Text_Control.php
+++ b/src/VK_Custom_Text_Control.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * VK Custom Text Control
+ *
+ * カスタマイザーの text 入力欄に、前後の補助文字列（input_before / input_after）と
+ * 説明文（description）を 1 つの control として表示するための独自 control。
+ * 単位ラベル付きの数値入力欄や、入力欄直下に注釈を表示したい場合に用いる。
+ *
+ * Previously each plugin (Lightning G3 Pro Unit, ExUnit, etc.) defined this class
+ * locally with a `class_exists()` guard. This file consolidates that definition
+ * inside the shared vk-admin package so plugins can rely on a single source of
+ * truth instead of copy/pasting the class.
+ *
+ * @package vektor-inc/vk-admin
+ * @license GPL-2.0+
+ */
+
+// グローバル名前空間（namespace 宣言なし）。
+// 既存プラグインが `new VK_Custom_Text_Control(...)` で利用しているため、
+// クラス名はグローバルのまま維持する必要がある。
+
+// WP_Customize_Control が存在しない環境（フロント側など）では本クラスを宣言しない。
+if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'VK_Custom_Text_Control' ) ) {
+
+	/**
+	 * VK_Custom_Text_Control
+	 *
+	 * WP_Customize_Control を継承し、テキスト入力欄の前後に補助文字列を、
+	 * 入力欄の下に description を出力できるようにした control。
+	 *
+	 * 公開プロパティ:
+	 *  - $type         : control の type 識別子（'customtext'）。
+	 *  - $description  : input の下に表示する説明文（wp_kses_post でエスケープ）。
+	 *  - $input_before : input の左側に表示する補助文字列（例: '$' などの単位記号）。
+	 *  - $input_after  : input の右側に表示する補助文字列（例: 'px' などの単位ラベル）。
+	 *
+	 * 利用例:
+	 *  $wp_customize->add_control(
+	 *      new VK_Custom_Text_Control(
+	 *          $wp_customize,
+	 *          'vk_admin_sample_width',
+	 *          array(
+	 *              'section'     => 'vk_admin_sample_section',
+	 *              'label'       => __( 'Width', 'your-textdomain' ),
+	 *              'description' => __( '幅と高さを揃えたい場合は両方指定してください。', 'your-textdomain' ),
+	 *              'input_after' => 'px',
+	 *          )
+	 *      )
+	 *  );
+	 */
+	class VK_Custom_Text_Control extends WP_Customize_Control {
+
+		/**
+		 * Control type.
+		 *
+		 * WP_Customize_Control が内部で参照する type 識別子。
+		 *
+		 * @var string
+		 */
+		public $type = 'customtext';
+
+		/**
+		 * Description displayed under the input.
+		 *
+		 * 入力欄の下に表示する説明文。wp_kses_post() でエスケープされる。
+		 *
+		 * @var string
+		 */
+		public $description = '';
+
+		/**
+		 * String displayed before the input.
+		 *
+		 * 入力欄の左側に表示する補助文字列。wp_kses_post() でエスケープされる。
+		 *
+		 * @var string
+		 */
+		public $input_before = '';
+
+		/**
+		 * String displayed after the input.
+		 *
+		 * 入力欄の右側に表示する補助文字列。wp_kses_post() でエスケープされる。
+		 *
+		 * @var string
+		 */
+		public $input_after = '';
+
+		/**
+		 * Render the control's content.
+		 *
+		 * ラベル・input_before・input 本体・input_after・description の順で出力する。
+		 * input_before / input_after が設定されている場合は input の幅を 50% に抑え、
+		 * 補助文字列との並びが破綻しないようにする。
+		 *
+		 * @return void
+		 */
+		public function render_content() {
+			// input_before / input_after があるときは input の幅を 50% に抑え、
+			// 補助文字列との並びを保つ。
+			$input_style = ( $this->input_before || $this->input_after ) ? ' style="width:50%"' : '';
+			?>
+			<label>
+				<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
+				<div>
+					<?php echo wp_kses_post( $this->input_before ); ?>
+					<input type="text" value="<?php echo esc_attr( $this->value() ); ?>"<?php echo $input_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- 内部で固定値のみを設定。 ?> <?php $this->link(); ?> />
+					<?php echo wp_kses_post( $this->input_after ); ?>
+				</div>
+				<?php if ( $this->description ) : ?>
+					<div class="description"><?php echo wp_kses_post( $this->description ); ?></div>
+				<?php endif; ?>
+			</label>
+			<?php
+		}
+	}
+}

--- a/src/VK_Custom_Text_Control.php
+++ b/src/VK_Custom_Text_Control.php
@@ -30,9 +30,10 @@ if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'VK_Custom_Text_C
 	 *
 	 * 公開プロパティ:
 	 *  - $type         : control の type 識別子（'customtext'）。
-	 *  - $description  : input の下に表示する説明文（wp_kses_post でエスケープ）。
 	 *  - $input_before : input の左側に表示する補助文字列（例: '$' などの単位記号）。
 	 *  - $input_after  : input の右側に表示する補助文字列（例: 'px' などの単位ラベル）。
+	 *
+	 * $description は親クラス WP_Customize_Control が提供するプロパティをそのまま利用する。
 	 *
 	 * 利用例:
 	 *  $wp_customize->add_control(
@@ -58,15 +59,6 @@ if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'VK_Custom_Text_C
 		 * @var string
 		 */
 		public $type = 'customtext';
-
-		/**
-		 * Description displayed under the input.
-		 *
-		 * 入力欄の下に表示する説明文。wp_kses_post() でエスケープされる。
-		 *
-		 * @var string
-		 */
-		public $description = '';
 
 		/**
 		 * String displayed before the input.


### PR DESCRIPTION
WordPressエンジニアの和田です。

## 概要

各プラグインで `class_exists()` ガード付きでコピペ展開されていたカスタマイザー用の独自 control クラスを、共通パッケージ `vk-admin` に本体として集約します。

- `VK_Custom_Html_Control` — ラベル・サブタイトル・任意 HTML をまとめて表示する control
- `VK_Custom_Text_Control` — text 入力欄の前後に補助文字列、入力欄の下に description を表示する control

## 背景

- ExUnit PR [vektor-inc/vk-all-in-one-expansion-unit#1363](https://github.com/vektor-inc/vk-all-in-one-expansion-unit/pull/1363) のカスタマイザーで、`width` / `height` 2 つの control にそれぞれ同じ説明文を直書きしてしまっており、design-rules.md の「共通の説明文は 1 箇所に集約する」に反した状態になっていました。
- 同じ説明文を 1 箇所にまとめたい場合に使える control が `VK_Custom_Html_Control` ですが、これまでは Lightning G3 Pro Unit や各プラグイン内で `class_exists()` ガード付きでローカル定義する形になっており、共通化されていませんでした（参考: [lightning-g3-pro-unit/inc/header-trans/class-lightning_header_trans.php](https://github.com/vektor-inc/lightning-g3-pro-unit/blob/master/inc/header-trans/class-lightning_header_trans.php) で `new VK_Custom_Html_Control(...)` / `new VK_Custom_Text_Control(...)` を利用）。
- そこで本 PR で `vk-admin` に本体実装を置き、各プラグインは順次 `vk-admin` 経由でこのクラスを利用する形にリファクタリングできるようにします（既存のローカル定義は `class_exists()` ガードで二重宣言を回避しているため、両者が共存しても問題は起きません）。

## 追加クラスの説明

### `VK_Custom_Html_Control`

カスタマイザーのセクション内に「セクションタイトル + サブタイトル + 任意 HTML」を一括出力するための control です。設定値そのものではなく、説明文や注意書きを表示する用途で使います。

公開プロパティ:
- `$type` — `'customtext'` 固定
- `$custom_title_sub` — ラベル直下の h3 として表示するサブタイトル
- `$custom_html` — `wp_kses_post()` でサニタイズして出力する任意 HTML

### `VK_Custom_Text_Control`

text 入力欄に「前後の補助文字列（input_before / input_after）」と「入力欄の下に description」を持たせる control です。`width` と `height` のように複数 control で同じ説明文を共有したいシナリオでも、まとめ役の `VK_Custom_Html_Control` と組み合わせて 1 箇所に集約できます。

公開プロパティ:
- `$type` — `'customtext'` 固定
- `$description` — input 下に表示する説明文（`wp_kses_post()` でエスケープ）
- `$input_before` — input 左側に表示する補助文字列（`wp_kses_post()` でエスケープ）
- `$input_after` — input 右側に表示する補助文字列（`wp_kses_post()` でエスケープ）

## 元実装からの変更点

[lightning-g3-pro-unit](https://github.com/vektor-inc/lightning-g3-pro-unit/blob/master/inc/header-trans/class-lightning_header_trans.php) を含む各プラグインで定義されているコードをベースに、以下を調整しています。

- `WP_Customize_Control` を継承（元実装どおり）
- `class_exists()` ガードは、`WP_Customize_Control` 未読込環境（フロント側など）と二重宣言の双方を防ぐ目的で残す
- PHPDoc を追記（クラス・プロパティ・メソッドそれぞれ）
- `VK_Custom_Text_Control` で `description` を素の `echo` していた箇所を `wp_kses_post()` でエスケープ
- `description` が空のときは空の `<div>` を出力しないよう条件分岐

## ファイル一覧

- `src/VK_Custom_Html_Control.php`（新規）
- `src/VK_Custom_Text_Control.php`（新規）
- `composer.json` — `autoload.files` に上記 2 ファイルを追加（グローバル名前空間のクラスなので psr-4 ではなく `files` 指定で読み込ませる）
- `README.md` — 使い方サンプルと changelog を追記

`src/VkAdmin.php` には一切手を入れていません。

## 確認手順

### 前提条件

- `composer install` 済み（または `composer dump-autoload` 済み）の WordPress 環境

### 手順

#### 1. PHP syntax

\`\`\`bash
php -l src/VK_Custom_Html_Control.php
php -l src/VK_Custom_Text_Control.php
\`\`\`
→ ✓ 両ファイルとも `No syntax errors detected`

#### 2. オートロードでクラスが読み込まれること

\`\`\`bash
php -r 'require "vendor/autoload.php"; class WP_Customize_Control {} \
  var_dump(class_exists("VK_Custom_Html_Control")); \
  var_dump(class_exists("VK_Custom_Text_Control"));'
\`\`\`
→ ✓ どちらも `bool(true)`

#### 3. `WP_Customize_Control` が未読込の環境ではクラスを宣言しないこと

\`\`\`bash
php -r 'require "vendor/autoload.php"; \
  var_dump(class_exists("VK_Custom_Html_Control", false));'
\`\`\`
→ ✓ `bool(false)` （フロント側で誤って読み込まれても何も起きないことの確認）

#### 4. カスタマイザーでの簡易動作確認

任意のテーマ／プラグインから以下を呼び出し、カスタマイザー画面で見た目を確認:

\`\`\`php
$wp_customize->add_section( 'vk_admin_demo', array( 'title' => 'VK Admin Demo' ) );
$wp_customize->add_setting( 'vk_admin_demo_width', array( 'default' => '' ) );
$wp_customize->add_control(
    new VK_Custom_Html_Control(
        $wp_customize,
        'vk_admin_demo_desc',
        array(
            'section'          => 'vk_admin_demo',
            'label'            => 'デモセクション',
            'custom_title_sub' => 'サブタイトル',
            'custom_html'      => '<p>共通の説明文をここに 1 回だけ書きます。</p>',
        )
    )
);
$wp_customize->add_control(
    new VK_Custom_Text_Control(
        $wp_customize,
        'vk_admin_demo_width',
        array(
            'section'     => 'vk_admin_demo',
            'label'       => '幅',
            'input_after' => 'px',
        )
    )
);
\`\`\`

→ ✓ カスタマイザーに「デモセクション（h2）／サブタイトル（h3）／説明文／幅入力欄＋単位 px」が表示される

## 互換性に関する補足

- クラス名はグローバル名前空間のまま維持しました。psr-4（`VektorInc\VK_Admin\` 配下）に置くと既存利用箇所の `new VK_Custom_Html_Control(...)` 表記を全プラグインで書き換えることになるため、API 互換を優先しています。
- 各プラグインで `class_exists()` ガード付きのローカル定義が残っていても、本パッケージ側でも同じガードを入れているため二重宣言にはなりません。プラグイン側のローカル定義は別 PR で順次撤去できます。
- 既存の `src/VkAdmin.php` には一切変更を入れていません。

## changelog / バージョン

- `README.md` の `## Change log` に英語で 1 行追記（既存エントリが全て英語のため）
- `composer.json` のパッケージバージョンは本 PR では変更しません（マージ後にリリースタグを切る運用に合わせます）

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * カスタマイザー向けの再利用可能なカスタムコントロールを2種追加しました（HTML表示／テキスト入力向け）。

* **ドキュメント**
  * READMEに各カスタムコントロールの用途説明と使用例コードを追記しました。
  * Changelogに該当コントロール追加を記載しました。

* **雑務**
  * 自動読み込み設定を更新し、該当コントロールを初期化時に読み込むようにしました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-admin/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->