### PR TITLE
[ 不具合修正 ] customize_register フックで遅延宣言して WP_Customize_Control 未読込時の Fatal error を回避

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ $wp_customize->add_control(
 
 ## Change log
 
+== 0.6.1 ==
+[ Bug Fix ] Defer VK_Custom_Html_Control / VK_Custom_Text_Control class declaration to the `customize_register` action so that the classes do not fail to load when `WP_Customize_Control` is not yet available at composer autoload time.
+
+== 0.6.0 ==
 [ Feature Add ] Add VK_Custom_Html_Control and VK_Custom_Text_Control as shared customizer controls for reuse across plugins.
 
 == 0.5.1 ==

--- a/src/VK_Custom_Html_Control.php
+++ b/src/VK_Custom_Html_Control.php
@@ -1,12 +1,21 @@
 <?php
 /**
- * VK Custom HTML Control
+ * VK Custom HTML Control loader.
  *
  * カスタマイザーで任意の HTML（説明文・補助情報など）を出力するための独自 control。
  * Previously each plugin (Lightning G3 Pro Unit, ExUnit, etc.) defined this class
  * locally with a `class_exists()` guard. This file consolidates that definition
  * inside the shared vk-admin package so plugins can rely on a single source of
  * truth instead of copy/pasting the class.
+ *
+ * Composer の `files` autoloader はプラグイン起動直後（`require_once vendor/autoload.php`）に
+ * 即ファイルを require する。この時点では WordPress コアの `WP_Customize_Control` がまだ
+ * 読み込まれていないため、即時に `class_exists( 'WP_Customize_Control' )` でガードしても
+ * クラス宣言ブロックがスキップされてしまい、後から `new VK_Custom_Html_Control(...)` を
+ * 呼んだ際に Fatal error が発生する。
+ *
+ * これを避けるため、`customize_register` アクション内で `WP_Customize_Control` が
+ * 読み込まれた後にクラス宣言を行う「遅延宣言」方式を採用している。
  *
  * @package vektor-inc/vk-admin
  * @license GPL-2.0+
@@ -16,84 +25,107 @@
 // 既存プラグインが `new VK_Custom_Html_Control(...)` で利用しているため、
 // クラス名はグローバルのまま維持する必要がある。
 
-// WP_Customize_Control が存在しない環境（フロント側など）では本クラスを宣言しない。
-if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'VK_Custom_Html_Control' ) ) {
+// 優先度 0 で customize_register に登録し、他の add_control 呼び出しより先に
+// クラス宣言が完了している状態を作る。
+// WordPress 環境外（phpcs などの静的解析 CLI から composer autoload された場合）でも
+// fatal にしないよう、`add_action()` の存在チェックでガードする。
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'customize_register', 'vk_admin_register_custom_html_control', 0 );
+}
 
+if ( ! function_exists( 'vk_admin_register_custom_html_control' ) ) {
 	/**
-	 * VK_Custom_Html_Control
+	 * VK_Custom_Html_Control を遅延宣言する。
 	 *
-	 * WP_Customize_Control を継承し、ラベル・サブタイトル・任意 HTML をまとめて
-	 * 出力するための control。設定値そのものではなく説明文や注意書きを
-	 * カスタマイザーのセクション内に表示する用途で利用する。
+	 * `customize_register` アクションのタイミングでは `WP_Customize_Control` が
+	 * 読み込まれているため、ここで初めてクラス宣言を行う。`class_exists()` には
+	 * 第 2 引数 `false` を渡し、autoload の発火による無限ループを防ぐ。
 	 *
-	 * 公開プロパティ:
-	 *  - $type             : control の type 識別子（'customtext'）。
-	 *  - $custom_title_sub : ラベルの直下に表示するサブタイトル（h3）。
-	 *  - $custom_html      : サブタイトルの下に表示する任意 HTML（wp_kses_post でエスケープ）。
-	 *
-	 * 利用例:
-	 *  $wp_customize->add_control(
-	 *      new VK_Custom_Html_Control(
-	 *          $wp_customize,
-	 *          'vk_admin_sample_description',
-	 *          array(
-	 *              'section'          => 'vk_admin_sample_section',
-	 *              'label'            => __( 'Section Title', 'your-textdomain' ),
-	 *              'custom_title_sub' => __( 'Sub Title', 'your-textdomain' ),
-	 *              'custom_html'      => '<p>' . esc_html__( '説明文', 'your-textdomain' ) . '</p>',
-	 *          )
-	 *      )
-	 *  );
+	 * @return void
 	 */
-	class VK_Custom_Html_Control extends WP_Customize_Control {
+	function vk_admin_register_custom_html_control() {
+		// WP_Customize_Control が未読込、または既にクラス宣言済みなら何もしない。
+		// 第 2 引数 false で autoload を発火させない。
+		if ( ! class_exists( 'WP_Customize_Control', false ) || class_exists( 'VK_Custom_Html_Control', false ) ) {
+			return;
+		}
 
 		/**
-		 * Control type.
+		 * VK_Custom_Html_Control
 		 *
-		 * WP_Customize_Control が内部で参照する type 識別子。
+		 * WP_Customize_Control を継承し、ラベル・サブタイトル・任意 HTML をまとめて
+		 * 出力するための control。設定値そのものではなく説明文や注意書きを
+		 * カスタマイザーのセクション内に表示する用途で利用する。
 		 *
-		 * @var string
+		 * 公開プロパティ:
+		 *  - $type             : control の type 識別子（'customtext'）。
+		 *  - $custom_title_sub : ラベルの直下に表示するサブタイトル（h3）。
+		 *  - $custom_html      : サブタイトルの下に表示する任意 HTML（wp_kses_post でエスケープ）。
+		 *
+		 * 利用例:
+		 *  $wp_customize->add_control(
+		 *      new VK_Custom_Html_Control(
+		 *          $wp_customize,
+		 *          'vk_admin_sample_description',
+		 *          array(
+		 *              'section'          => 'vk_admin_sample_section',
+		 *              'label'            => __( 'Section Title', 'your-textdomain' ),
+		 *              'custom_title_sub' => __( 'Sub Title', 'your-textdomain' ),
+		 *              'custom_html'      => '<p>' . esc_html__( '説明文', 'your-textdomain' ) . '</p>',
+		 *          )
+		 *      )
+		 *  );
 		 */
-		public $type = 'customtext';
+		class VK_Custom_Html_Control extends WP_Customize_Control {
 
-		/**
-		 * Sub title shown under the main label.
-		 *
-		 * label の直下に h3 として表示するサブタイトル。
-		 *
-		 * @var string
-		 */
-		public $custom_title_sub = '';
+			/**
+			 * Control type.
+			 *
+			 * WP_Customize_Control が内部で参照する type 識別子。
+			 *
+			 * @var string
+			 */
+			public $type = 'customtext';
 
-		/**
-		 * Arbitrary HTML displayed below the sub title.
-		 *
-		 * 任意 HTML。wp_kses_post() で出力時にサニタイズされる。
-		 *
-		 * @var string
-		 */
-		public $custom_html = '';
+			/**
+			 * Sub title shown under the main label.
+			 *
+			 * label の直下に h3 として表示するサブタイトル。
+			 *
+			 * @var string
+			 */
+			public $custom_title_sub = '';
 
-		/**
-		 * Render the control's content.
-		 *
-		 * ラベル → サブタイトル → 任意 HTML の順で出力する。
-		 * いずれも未設定の場合は何も出力しない。
-		 *
-		 * @return void
-		 */
-		public function render_content() {
-			// ラベルが設定されていれば h2 として出力する。
-			if ( $this->label ) {
-				echo '<h2 class="admin-custom-h2">' . wp_kses_post( $this->label ) . '</h2>';
-			}
-			// サブタイトルが設定されていれば h3 として出力する。
-			if ( $this->custom_title_sub ) {
-				echo '<h3 class="admin-custom-h3">' . wp_kses_post( $this->custom_title_sub ) . '</h3>';
-			}
-			// 任意 HTML が設定されていれば div でラップして出力する。
-			if ( $this->custom_html ) {
-				echo '<div>' . wp_kses_post( $this->custom_html ) . '</div>';
+			/**
+			 * Arbitrary HTML displayed below the sub title.
+			 *
+			 * 任意 HTML。wp_kses_post() で出力時にサニタイズされる。
+			 *
+			 * @var string
+			 */
+			public $custom_html = '';
+
+			/**
+			 * Render the control's content.
+			 *
+			 * ラベル → サブタイトル → 任意 HTML の順で出力する。
+			 * いずれも未設定の場合は何も出力しない。
+			 *
+			 * @return void
+			 */
+			public function render_content() {
+				// ラベルが設定されていれば h2 として出力する。
+				if ( $this->label ) {
+					echo '<h2 class="admin-custom-h2">' . wp_kses_post( $this->label ) . '</h2>';
+				}
+				// サブタイトルが設定されていれば h3 として出力する。
+				if ( $this->custom_title_sub ) {
+					echo '<h3 class="admin-custom-h3">' . wp_kses_post( $this->custom_title_sub ) . '</h3>';
+				}
+				// 任意 HTML が設定されていれば div でラップして出力する。
+				if ( $this->custom_html ) {
+					echo '<div>' . wp_kses_post( $this->custom_html ) . '</div>';
+				}
 			}
 		}
 	}

--- a/src/VK_Custom_Text_Control.php
+++ b/src/VK_Custom_Text_Control.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * VK Custom Text Control
+ * VK Custom Text Control loader.
  *
  * カスタマイザーの text 入力欄に、前後の補助文字列（input_before / input_after）と
  * 説明文（description）を 1 つの control として表示するための独自 control。
@@ -11,6 +11,15 @@
  * inside the shared vk-admin package so plugins can rely on a single source of
  * truth instead of copy/pasting the class.
  *
+ * Composer の `files` autoloader はプラグイン起動直後（`require_once vendor/autoload.php`）に
+ * 即ファイルを require する。この時点では WordPress コアの `WP_Customize_Control` がまだ
+ * 読み込まれていないため、即時に `class_exists( 'WP_Customize_Control' )` でガードしても
+ * クラス宣言ブロックがスキップされてしまい、後から `new VK_Custom_Text_Control(...)` を
+ * 呼んだ際に Fatal error が発生する。
+ *
+ * これを避けるため、`customize_register` アクション内で `WP_Customize_Control` が
+ * 読み込まれた後にクラス宣言を行う「遅延宣言」方式を採用している。
+ *
  * @package vektor-inc/vk-admin
  * @license GPL-2.0+
  */
@@ -19,91 +28,114 @@
 // 既存プラグインが `new VK_Custom_Text_Control(...)` で利用しているため、
 // クラス名はグローバルのまま維持する必要がある。
 
-// WP_Customize_Control が存在しない環境（フロント側など）では本クラスを宣言しない。
-if ( class_exists( 'WP_Customize_Control' ) && ! class_exists( 'VK_Custom_Text_Control' ) ) {
+// 優先度 0 で customize_register に登録し、他の add_control 呼び出しより先に
+// クラス宣言が完了している状態を作る。
+// WordPress 環境外（phpcs などの静的解析 CLI から composer autoload された場合）でも
+// fatal にしないよう、`add_action()` の存在チェックでガードする。
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'customize_register', 'vk_admin_register_custom_text_control', 0 );
+}
 
+if ( ! function_exists( 'vk_admin_register_custom_text_control' ) ) {
 	/**
-	 * VK_Custom_Text_Control
+	 * VK_Custom_Text_Control を遅延宣言する。
 	 *
-	 * WP_Customize_Control を継承し、テキスト入力欄の前後に補助文字列を、
-	 * 入力欄の下に description を出力できるようにした control。
+	 * `customize_register` アクションのタイミングでは `WP_Customize_Control` が
+	 * 読み込まれているため、ここで初めてクラス宣言を行う。`class_exists()` には
+	 * 第 2 引数 `false` を渡し、autoload の発火による無限ループを防ぐ。
 	 *
-	 * 公開プロパティ:
-	 *  - $type         : control の type 識別子（'customtext'）。
-	 *  - $input_before : input の左側に表示する補助文字列（例: '$' などの単位記号）。
-	 *  - $input_after  : input の右側に表示する補助文字列（例: 'px' などの単位ラベル）。
-	 *
-	 * $description は親クラス WP_Customize_Control が提供するプロパティをそのまま利用する。
-	 *
-	 * 利用例:
-	 *  $wp_customize->add_control(
-	 *      new VK_Custom_Text_Control(
-	 *          $wp_customize,
-	 *          'vk_admin_sample_width',
-	 *          array(
-	 *              'section'     => 'vk_admin_sample_section',
-	 *              'label'       => __( 'Width', 'your-textdomain' ),
-	 *              'description' => __( '幅と高さを揃えたい場合は両方指定してください。', 'your-textdomain' ),
-	 *              'input_after' => 'px',
-	 *          )
-	 *      )
-	 *  );
+	 * @return void
 	 */
-	class VK_Custom_Text_Control extends WP_Customize_Control {
+	function vk_admin_register_custom_text_control() {
+		// WP_Customize_Control が未読込、または既にクラス宣言済みなら何もしない。
+		// 第 2 引数 false で autoload を発火させない。
+		if ( ! class_exists( 'WP_Customize_Control', false ) || class_exists( 'VK_Custom_Text_Control', false ) ) {
+			return;
+		}
 
 		/**
-		 * Control type.
+		 * VK_Custom_Text_Control
 		 *
-		 * WP_Customize_Control が内部で参照する type 識別子。
+		 * WP_Customize_Control を継承し、テキスト入力欄の前後に補助文字列を、
+		 * 入力欄の下に description を出力できるようにした control。
 		 *
-		 * @var string
+		 * 公開プロパティ:
+		 *  - $type         : control の type 識別子（'customtext'）。
+		 *  - $input_before : input の左側に表示する補助文字列（例: '$' などの単位記号）。
+		 *  - $input_after  : input の右側に表示する補助文字列（例: 'px' などの単位ラベル）。
+		 *
+		 * $description は親クラス WP_Customize_Control が提供するプロパティをそのまま利用する。
+		 *
+		 * 利用例:
+		 *  $wp_customize->add_control(
+		 *      new VK_Custom_Text_Control(
+		 *          $wp_customize,
+		 *          'vk_admin_sample_width',
+		 *          array(
+		 *              'section'     => 'vk_admin_sample_section',
+		 *              'label'       => __( 'Width', 'your-textdomain' ),
+		 *              'description' => __( '幅と高さを揃えたい場合は両方指定してください。', 'your-textdomain' ),
+		 *              'input_after' => 'px',
+		 *          )
+		 *      )
+		 *  );
 		 */
-		public $type = 'customtext';
+		class VK_Custom_Text_Control extends WP_Customize_Control {
 
-		/**
-		 * String displayed before the input.
-		 *
-		 * 入力欄の左側に表示する補助文字列。wp_kses_post() でエスケープされる。
-		 *
-		 * @var string
-		 */
-		public $input_before = '';
+			/**
+			 * Control type.
+			 *
+			 * WP_Customize_Control が内部で参照する type 識別子。
+			 *
+			 * @var string
+			 */
+			public $type = 'customtext';
 
-		/**
-		 * String displayed after the input.
-		 *
-		 * 入力欄の右側に表示する補助文字列。wp_kses_post() でエスケープされる。
-		 *
-		 * @var string
-		 */
-		public $input_after = '';
+			/**
+			 * String displayed before the input.
+			 *
+			 * 入力欄の左側に表示する補助文字列。wp_kses_post() でエスケープされる。
+			 *
+			 * @var string
+			 */
+			public $input_before = '';
 
-		/**
-		 * Render the control's content.
-		 *
-		 * ラベル・input_before・input 本体・input_after・description の順で出力する。
-		 * input_before / input_after が設定されている場合は input の幅を 50% に抑え、
-		 * 補助文字列との並びが破綻しないようにする。
-		 *
-		 * @return void
-		 */
-		public function render_content() {
-			// input_before / input_after があるときは input の幅を 50% に抑え、
-			// 補助文字列との並びを保つ。
-			$input_style = ( $this->input_before || $this->input_after ) ? ' style="width:50%"' : '';
-			?>
-			<label>
-				<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
-				<div>
-					<?php echo wp_kses_post( $this->input_before ); ?>
-					<input type="text" value="<?php echo esc_attr( $this->value() ); ?>"<?php echo $input_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- 内部で固定値のみを設定。 ?> <?php $this->link(); ?> />
-					<?php echo wp_kses_post( $this->input_after ); ?>
-				</div>
-				<?php if ( $this->description ) : ?>
-					<div class="description"><?php echo wp_kses_post( $this->description ); ?></div>
-				<?php endif; ?>
-			</label>
-			<?php
+			/**
+			 * String displayed after the input.
+			 *
+			 * 入力欄の右側に表示する補助文字列。wp_kses_post() でエスケープされる。
+			 *
+			 * @var string
+			 */
+			public $input_after = '';
+
+			/**
+			 * Render the control's content.
+			 *
+			 * ラベル・input_before・input 本体・input_after・description の順で出力する。
+			 * input_before / input_after が設定されている場合は input の幅を 50% に抑え、
+			 * 補助文字列との並びが破綻しないようにする。
+			 *
+			 * @return void
+			 */
+			public function render_content() {
+				// input_before / input_after があるときは input の幅を 50% に抑え、
+				// 補助文字列との並びを保つ。
+				$input_style = ( $this->input_before || $this->input_after ) ? ' style="width:50%"' : '';
+				?>
+				<label>
+					<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
+					<div>
+						<?php echo wp_kses_post( $this->input_before ); ?>
+						<input type="text" value="<?php echo esc_attr( $this->value() ); ?>"<?php echo $input_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- 内部で固定値のみを設定。 ?> <?php $this->link(); ?> />
+						<?php echo wp_kses_post( $this->input_after ); ?>
+					</div>
+					<?php if ( $this->description ) : ?>
+						<div class="description"><?php echo wp_kses_post( $this->description ); ?></div>
+					<?php endif; ?>
+				</label>
+				<?php
+			}
 		}
 	}
 }


### PR DESCRIPTION
WordPress エンジニアの和田です。

vk-admin 0.6.0 で追加した `VK_Custom_Html_Control` / `VK_Custom_Text_Control` の本質的なロード時不具合を修正します。

## 背景・原因

composer の `files` autoloader はプラグイン起動直後（`require_once vendor/autoload.php`）に即ファイルを require します。この時点では WordPress コアの `WP_Customize_Control` がまだ読み込まれていないため、現状のトップレベル `class_exists( 'WP_Customize_Control' )` ガードは **常に false** になり、クラス宣言ブロックがスキップされます。

その結果、後段で `new VK_Custom_Html_Control(...)` / `new VK_Custom_Text_Control(...)` を呼ぶプラグイン側で次の Fatal error が発生します。

```
Fatal error: Class "VK_Custom_Html_Control" not found
```

ExUnit 側で fallback include を入れて凌いだ状態ですが、vk-admin を利用する他のプラグインでも同じ問題が起こるため、共有パッケージ側で根本対応します。

## 修正方針

- トップレベルの即時 `class_exists( 'WP_Customize_Control' )` ガードを廃止
- `customize_register` アクション（優先度 `0`）の中でクラス宣言を行う「**遅延宣言**」方式に変更
- 関数名は `vk_admin_register_custom_html_control` / `vk_admin_register_custom_text_control` で衝突を回避
- `class_exists( ..., false )` で autoload の発火による無限ループを防止
- WordPress 環境外（phpcs 等の静的解析 CLI から composer autoload された場合）でも fatal にならないよう、`add_action()` を `function_exists()` でガード

## 変更ファイル

- `src/VK_Custom_Html_Control.php` — 遅延宣言方式に変更
- `src/VK_Custom_Text_Control.php` — 遅延宣言方式に変更
- `README.md` — Change log に 0.6.1 のエントリを追加（既存の 0.6.0 エントリも合わせて見出しを補完）

`composer.json` のバージョンは PR 段階では変更していません。

## 確認手順

### 前提条件

- ローカル WordPress 環境にこのブランチの vk-admin を composer 経由で導入できること
- カスタマイザーで `VK_Custom_Html_Control` / `VK_Custom_Text_Control` を `add_control` するプラグイン（例: ExUnit）が有効化されていること

### Before（修正前の再現手順）

1. vk-admin 0.6.0 を入れた状態で、ExUnit などから fallback include を外して `vendor/autoload.php` 経由のみで vk-admin をロードさせる
2. 管理画面を開く
   - 期待: 動かない（Fatal error: Class "VK_Custom_Html_Control" not found）

### After（修正後）

1. このブランチを composer で取り込む（`composer update vektor-inc/vk-admin`）
2. fallback include 無しの状態で管理画面 → 外観 → カスタマイズを開く
   - 期待: Fatal error が出ない
3. `VK_Custom_Html_Control` / `VK_Custom_Text_Control` を `add_control` しているセクションをカスタマイザーで開く
   - 期待: ラベル / サブタイトル / HTML / 補助文字列・description が従来通り表示される
4. フロント側で適当なページを表示する
   - 期待: フロント側では `customize_register` が発火しないため、クラス宣言は行われず副作用なし
5. CLI から `php -l src/VK_Custom_Html_Control.php` / `php -l src/VK_Custom_Text_Control.php`
   - 期待: `No syntax errors detected`

## スクリーンショット

純粋なロード順の修正で表示は変わらないため省略します。

## 補足

- `composer.json` のバージョン更新（0.6.1）はリリーススキル側で別途実施予定です。
- CodeRabbit 監視は司側で実施予定です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.6.1

* **Bug Fixes**
  * Fixed an issue where custom controls failed to load in certain environments, improving compatibility and stability.

* **Chores**
  * Updated README with version 0.6.1 changelog.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-admin/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->