### PR TITLE
[ 機能追加 ] VK_Custom_Text_Control に input_type / input_attrs プロパティを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,41 @@ $wp_customize->add_control(
 );
 ```
 
+#### input_type / input_attrs（type=number 等への対応）
+
+`input_type` で input の type 属性を、`input_attrs` で任意の属性（`min` / `max` / `step` / `inputmode` / `data-*` / `aria-*` 等）を指定できます。
+画像サイズ入力など、数値専用の入力欄を作りたいときに利用してください。
+
+```php
+$wp_customize->add_control(
+    new VK_Custom_Text_Control(
+        $wp_customize,
+        'your_setting_image_width',
+        array(
+            'section'     => 'your_section',
+            'label'       => __( 'Image width', 'your-textdomain' ),
+            'input_type'  => 'number',
+            'input_after' => 'px',
+            'input_attrs' => array(
+                'min'       => 1,
+                'max'       => 500,
+                'step'      => 1,
+                'inputmode' => 'numeric',
+            ),
+        )
+    )
+);
+```
+
+`input_type` を省略した場合は従来どおり `text` として動作します（後方互換）。
+
 
 ---
 
 ## Change log
+
+== 0.7.0 ==
+[ Feature Add ] Add `input_type` and `input_attrs` properties to `VK_Custom_Text_Control` so it can render `type=number` and other input types with arbitrary attributes (`min` / `max` / `step` / `inputmode` etc). Existing usage keeps working unchanged because both properties default to the previous behavior (`input_type='text'`, `input_attrs=array()`).
 
 == 0.6.1 ==
 [ Bug Fix ] Defer VK_Custom_Html_Control / VK_Custom_Text_Control class declaration to the `customize_register` action so that the classes do not fail to load when `WP_Customize_Control` is not yet available at composer autoload time.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ $wp_customize->add_control(
 
 `input_type` を省略した場合は従来どおり `text` として動作します（後方互換）。
 
+##### `input_attrs` の安全性
+
+`input_attrs` に渡した値はバリデーションを通った上で出力されます。安全性・既存プロパティとの衝突回避のため、以下の属性は自動的に除外されます。
+
+- `type` / `value` / `style` の各属性（`type` / `value` は既存プロパティと衝突。`style` は `esc_attr()` だけでは XSS を防ぎきれないため）
+- `on*` から始まる属性（`onclick` / `onload` などのイベントハンドラ）
+
+また、属性値は **scalar（文字列・数値・bool）** のみ許可されます。配列・オブジェクト・`null` を渡した場合はその属性自体が出力されません。`bool` を渡した場合は HTML5 の boolean attribute として扱われ、`true` なら属性名のみが出力され、`false` なら属性自体が省略されます。
+
 
 ---
 

--- a/src/VK_Custom_Text_Control.php
+++ b/src/VK_Custom_Text_Control.php
@@ -137,6 +137,13 @@ if ( ! function_exists( 'vk_admin_register_custom_text_control' ) ) {
 			 * 属性名・属性値ともに esc_attr() でエスケープして出力するため、
 			 * data-* / aria-* 等もそのまま渡すことができる。
 			 *
+			 * セキュリティおよび既存プロパティとの衝突回避のため、render_content() 内で
+			 * 以下の属性は自動的に除外される:
+			 * - 'type' / 'value' / 'style'（既存プロパティと衝突、または XSS リスク）
+			 * - 'on*'（onclick / onload 等のイベントハンドラ）
+			 * また、属性値は scalar のみ許可（配列・オブジェクト・null はスキップ）。
+			 * bool 値は HTML5 boolean attribute として扱われる（true なら属性名のみ出力）。
+			 *
 			 * @var array
 			 */
 			public $input_attrs = array();
@@ -172,9 +179,40 @@ if ( ! function_exists( 'vk_admin_register_custom_text_control' ) ) {
 						<input
 							type="<?php echo esc_attr( $input_type ); ?>"
 							value="<?php echo esc_attr( $this->value() ); ?>"
-							<?php // 任意属性（min / max / step / inputmode / data-* / aria-* など）。 ?>
-							<?php foreach ( $input_attrs as $attr_name => $attr_value ) : ?>
-								<?php echo esc_attr( $attr_name ); ?>="<?php echo esc_attr( $attr_value ); ?>"
+							<?php
+							// 任意属性（min / max / step / inputmode / data-* / aria-* など）。
+							// 属性名・属性値のバリデーションを行い、不正な値や危険な属性は出力しない。
+							// - 属性名: 文字列かつ非空のもののみ許可。
+							// - 'on*'（onclick / onload 等のイベントハンドラ）はスキップ。
+							// - 予約属性（type / value / style）はクラスの既存プロパティと衝突するためスキップ。
+							//   さらに style は esc_attr() だけでは XSS を防ぎきれないので一律除外。
+							// - 属性値: スカラーのみ許可。bool true は HTML5 boolean attribute として
+							//   属性名のみを出力、bool false は省略。null・配列・オブジェクトは出力しない。
+							$reserved_attrs = array( 'type', 'value', 'style' );
+							foreach ( $input_attrs as $attr_name => $attr_value ) :
+								// 属性名が文字列でない、または空文字ならスキップ。
+								if ( ! is_string( $attr_name ) || '' === $attr_name ) {
+									continue;
+								}
+								// 比較は小文字で行う（HTML 属性名は大文字小文字を区別しないため）。
+								$attr_name_lc = strtolower( $attr_name );
+								// イベントハンドラ系（on*）と予約属性は出力しない。
+								if ( 0 === strpos( $attr_name_lc, 'on' ) || in_array( $attr_name_lc, $reserved_attrs, true ) ) {
+									continue;
+								}
+								// bool 値は HTML5 boolean attribute として扱う（true なら属性名のみ、false なら省略）。
+								if ( is_bool( $attr_value ) ) {
+									if ( $attr_value ) {
+										echo esc_attr( $attr_name );
+									}
+									continue;
+								}
+								// null / 配列 / オブジェクトはそのまま esc_attr に渡せないのでスキップ。
+								if ( null === $attr_value || ! is_scalar( $attr_value ) ) {
+									continue;
+								}
+								?>
+								<?php echo esc_attr( $attr_name ); ?>="<?php echo esc_attr( (string) $attr_value ); ?>"
 							<?php endforeach; ?>
 							<?php echo $input_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- 内部で固定値のみを設定。 ?>
 							<?php $this->link(); ?>

--- a/src/VK_Custom_Text_Control.php
+++ b/src/VK_Custom_Text_Control.php
@@ -63,6 +63,8 @@ if ( ! function_exists( 'vk_admin_register_custom_text_control' ) ) {
 		 *  - $type         : control の type 識別子（'customtext'）。
 		 *  - $input_before : input の左側に表示する補助文字列（例: '$' などの単位記号）。
 		 *  - $input_after  : input の右側に表示する補助文字列（例: 'px' などの単位ラベル）。
+		 *  - $input_type   : input 要素の type 属性（例: 'text', 'number', 'email' など）。
+		 *  - $input_attrs  : input 要素に出力する任意属性の連想配列（例: array( 'min' => 1, 'max' => 500 )）。
 		 *
 		 * $description は親クラス WP_Customize_Control が提供するプロパティをそのまま利用する。
 		 *
@@ -75,7 +77,14 @@ if ( ! function_exists( 'vk_admin_register_custom_text_control' ) ) {
 		 *              'section'     => 'vk_admin_sample_section',
 		 *              'label'       => __( 'Width', 'your-textdomain' ),
 		 *              'description' => __( '幅と高さを揃えたい場合は両方指定してください。', 'your-textdomain' ),
+		 *              'input_type'  => 'number',
 		 *              'input_after' => 'px',
+		 *              'input_attrs' => array(
+		 *                  'min'       => 1,
+		 *                  'max'       => 500,
+		 *                  'step'      => 1,
+		 *                  'inputmode' => 'numeric',
+		 *              ),
 		 *          )
 		 *      )
 		 *  );
@@ -110,11 +119,37 @@ if ( ! function_exists( 'vk_admin_register_custom_text_control' ) ) {
 			public $input_after = '';
 
 			/**
+			 * Input type attribute.
+			 *
+			 * input 要素の type 属性に出力する文字列。
+			 * 例: 'text', 'number', 'email', 'url', 'tel', 'password' など。
+			 * 空文字や非文字列が指定された場合は render 時に 'text' へフォールバックする。
+			 *
+			 * @var string
+			 */
+			public $input_type = 'text';
+
+			/**
+			 * Extra input attributes.
+			 *
+			 * input 要素に追加で出力する任意属性の連想配列。
+			 * 例: array( 'min' => 1, 'max' => 500, 'step' => 1, 'inputmode' => 'numeric', 'pattern' => '\\d+' )
+			 * 属性名・属性値ともに esc_attr() でエスケープして出力するため、
+			 * data-* / aria-* 等もそのまま渡すことができる。
+			 *
+			 * @var array
+			 */
+			public $input_attrs = array();
+
+			/**
 			 * Render the control's content.
 			 *
 			 * ラベル・input_before・input 本体・input_after・description の順で出力する。
 			 * input_before / input_after が設定されている場合は input の幅を 50% に抑え、
 			 * 補助文字列との並びが破綻しないようにする。
+			 *
+			 * input_type / input_attrs を併用することで、type=number 等の他の input タイプや
+			 * min / max / step / inputmode などの任意属性を出力できる。
 			 *
 			 * @return void
 			 */
@@ -122,12 +157,28 @@ if ( ! function_exists( 'vk_admin_register_custom_text_control' ) ) {
 				// input_before / input_after があるときは input の幅を 50% に抑え、
 				// 補助文字列との並びを保つ。
 				$input_style = ( $this->input_before || $this->input_after ) ? ' style="width:50%"' : '';
+
+				// input_type が空文字や非文字列の場合は 'text' にフォールバックする防御。
+				// ホワイトリスト的なチェックは行わないが、esc_attr で XSS は防止される。
+				$input_type = ( is_string( $this->input_type ) && '' !== $this->input_type ) ? $this->input_type : 'text';
+
+				// input_attrs が配列でない場合に foreach で fatal を起こさないよう配列にフォールバック。
+				$input_attrs = is_array( $this->input_attrs ) ? $this->input_attrs : array();
 				?>
 				<label>
 					<span class="customize-control-title"><?php echo esc_html( $this->label ); ?></span>
 					<div>
 						<?php echo wp_kses_post( $this->input_before ); ?>
-						<input type="text" value="<?php echo esc_attr( $this->value() ); ?>"<?php echo $input_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- 内部で固定値のみを設定。 ?> <?php $this->link(); ?> />
+						<input
+							type="<?php echo esc_attr( $input_type ); ?>"
+							value="<?php echo esc_attr( $this->value() ); ?>"
+							<?php // 任意属性（min / max / step / inputmode / data-* / aria-* など）。 ?>
+							<?php foreach ( $input_attrs as $attr_name => $attr_value ) : ?>
+								<?php echo esc_attr( $attr_name ); ?>="<?php echo esc_attr( $attr_value ); ?>"
+							<?php endforeach; ?>
+							<?php echo $input_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- 内部で固定値のみを設定。 ?>
+							<?php $this->link(); ?>
+						/>
 						<?php echo wp_kses_post( $this->input_after ); ?>
 					</div>
 					<?php if ( $this->description ) : ?>


### PR DESCRIPTION
WordPressエンジニアの和田です。

## 概要

`VK_Custom_Text_Control` の input を type=text 固定から脱却し、`type=number` 等の他タイプや、`min` / `max` / `step` / `inputmode` などの任意属性を出力できるように拡張します。

ExUnit PR #1363 で width / height 入力欄を `VK_Custom_Text_Control` + `input_after='px'` で作りたいが、現状 type=text 固定なのが障害になっている、という背景を受けた対応です。

## 変更内容

`VK_Custom_Text_Control` クラスに以下のプロパティを追加しました。

- `$input_type` (string, default `'text'`)
  - input 要素の type 属性。`'text'` / `'number'` / `'email'` / `'url'` / `'tel'` / `'password'` 等を想定。
  - 空文字や非文字列が指定された場合は `'text'` にフォールバックする防御を入れています。
- `$input_attrs` (array, default `array()`)
  - input 要素に追加で出力する任意属性の連想配列。
  - 例: `array( 'min' => 1, 'max' => 500, 'step' => 1, 'inputmode' => 'numeric', 'pattern' => '\d+' )`
  - 属性名・属性値ともに `esc_attr()` でエスケープして出力するため、`data-*` / `aria-*` 等もそのまま渡せます。
  - 配列以外が指定された場合は空配列にフォールバックする防御を入れています。

`render_content()` では既存の `input type="text"` を `input_type` 由来の type 属性に置き換え、`input_attrs` を foreach で属性として展開する形に変更しています。

## 利用例

```php
new VK_Custom_Text_Control(
    $wp_customize,
    'setting_id',
    array(
        'label'        => 'Image width',
        'section'      => 'my_section',
        'input_type'   => 'number',
        'input_after'  => 'px',
        'input_attrs'  => array(
            'min'       => 1,
            'max'       => 500,
            'step'      => 1,
            'inputmode' => 'numeric',
        ),
    )
);
```

## 後方互換

- 両プロパティともデフォルト値（`input_type='text'`, `input_attrs=array()`）で既存挙動と同等になります。
- 既存利用箇所（vk-admin 0.6.x を利用しているプラグイン）は影響を受けません。
- 後方互換確認の方法:
  - 既存呼び出し（`input_type` / `input_attrs` 未指定）でカスタマイザーを開き、type=text のまま入力欄が描画されること
  - `input_before` / `input_after` を併用したとき、従来どおり `style="width:50%"` が付与されること
  - 新たに `input_type='number'` + `input_attrs=array('min'=>1, 'max'=>500)` を指定し、ブラウザ側で number input のスピンボタンと min/max 制約が効くこと

## セキュリティ

- 属性名・属性値はすべて `esc_attr()` でエスケープして出力しているため XSS は防止できます。
- `input_type` のホワイトリスト的チェックは行っていません（任意の input type を許容する柔軟性を優先）。

## バージョン

- README.md の Change log に `== 0.7.0 ==` のエントリを追加しました。
- composer.json のバージョンは本 PR では変更していません（リリース時に別途）。

## 動作確認

- `php -l src/VK_Custom_Text_Control.php` PASS
- `vendor/bin/phpcs src/VK_Custom_Text_Control.php` は main と同じ既存違反のみ（本変更で新規違反は導入なし）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * カスタムテキストコントロールに `input_type` を追加し、数値入力など複数の input タイプを指定可能に
  * `input_attrs` を追加し、`min`/`max`/`step`/`inputmode`/`data-*`/`aria-*` 等の任意属性を付与可能（boolean 属性は HTML5 規約に準拠）
  * 既存の利用はデフォルトで後方互換を維持

* **ドキュメント**
  * README と変更履歴に新オプションの説明と動作ルールを追記

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-admin/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->