### PR TITLE
[ 機能追加 ] VK_Custom_Html_Control に label_tag プロパティを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,30 @@ $wp_customize->add_control(
 );
 ```
 
+#### label_tag（見出しタグの切り替え）
+
+`label_tag` で label を囲む見出しタグを指定できます。親セクション（h2）配下の子セクション見出しとして h3 を使うなど、情報階層に合わせて見出しレベルを下げたい場合に利用します。
+
+```php
+$wp_customize->add_control(
+    new VK_Custom_Html_Control(
+        $wp_customize,
+        'setting_id',
+        array(
+            'label'       => __( 'Image size', 'your-textdomain' ),
+            'label_tag'   => 'h3', // 親の h2 配下の子セクション見出しとして h3 を使う
+            'section'     => 'my_section',
+            'custom_html' => '<p>' . esc_html__( '説明文', 'your-textdomain' ) . '</p>',
+        )
+    )
+);
+```
+
+- 許容値: `'h2'` / `'h3'` / `'h4'` / `'h5'` / `'h6'`
+- 上記以外を指定した場合は安全のため `'h2'` にフォールバックします。
+- 省略時のデフォルトは `'h2'` のため、既存利用箇所への影響はありません（後方互換）。
+- 出力される CSS クラスはタグに対応した `admin-custom-h2` / `admin-custom-h3` / `admin-custom-h4` / `admin-custom-h5` / `admin-custom-h6` になります。`admin-custom-h2` は従来から存在するクラスのためデフォルト挙動はそのままです。`h3` 以降のスタイルは vk-admin 側では同梱していないため、各プラグイン・テーマ側で必要に応じて用意してください。
+
 ### VK_Custom_Text_Control
 
 text 入力欄の前後に補助文字列（例: 単位ラベル）を、入力欄の下に共通 description を
@@ -111,6 +135,9 @@ $wp_customize->add_control(
 ---
 
 ## Change log
+
+== 0.8.0 ==
+[ Feature Add ] Add `label_tag` property to `VK_Custom_Html_Control` so it can render the label heading as `h2` / `h3` / `h4` / `h5` / `h6`. This allows child sections (e.g. "Image size" inside a parent "Page top button image" section) to use a lower heading level (`h3`) to keep the information hierarchy consistent. Existing usage keeps working unchanged because the property defaults to `'h2'` (renders the same `<h2 class="admin-custom-h2">` markup as before).
 
 == 0.7.0 ==
 [ Feature Add ] Add `input_type` and `input_attrs` properties to `VK_Custom_Text_Control` so it can render `type=number` and other input types with arbitrary attributes (`min` / `max` / `step` / `inputmode` etc). Existing usage keeps working unchanged because both properties default to the previous behavior (`input_type='text'`, `input_attrs=array()`).

--- a/src/VK_Custom_Html_Control.php
+++ b/src/VK_Custom_Html_Control.php
@@ -59,6 +59,7 @@ if ( ! function_exists( 'vk_admin_register_custom_html_control' ) ) {
 		 *
 		 * 公開プロパティ:
 		 *  - $type             : control の type 識別子（'customtext'）。
+		 *  - $label_tag        : label を囲む見出しタグ（'h2' / 'h3' / 'h4' / 'h5' / 'h6'、デフォルト 'h2'）。
 		 *  - $custom_title_sub : ラベルの直下に表示するサブタイトル（h3）。
 		 *  - $custom_html      : サブタイトルの下に表示する任意 HTML（wp_kses_post でエスケープ）。
 		 *
@@ -75,6 +76,20 @@ if ( ! function_exists( 'vk_admin_register_custom_html_control' ) ) {
 		 *          )
 		 *      )
 		 *  );
+		 *
+		 * label_tag の利用例（親 h2 配下の子セクション見出しとして h3 を使う）:
+		 *  $wp_customize->add_control(
+		 *      new VK_Custom_Html_Control(
+		 *          $wp_customize,
+		 *          'vk_admin_sample_subsection',
+		 *          array(
+		 *              'section'     => 'vk_admin_sample_section',
+		 *              'label'       => __( 'Image size', 'your-textdomain' ),
+		 *              'label_tag'   => 'h3',
+		 *              'custom_html' => '<p>' . esc_html__( '説明文', 'your-textdomain' ) . '</p>',
+		 *          )
+		 *      )
+		 *  );
 		 */
 		class VK_Custom_Html_Control extends WP_Customize_Control {
 
@@ -86,6 +101,19 @@ if ( ! function_exists( 'vk_admin_register_custom_html_control' ) ) {
 			 * @var string
 			 */
 			public $type = 'customtext';
+
+			/**
+			 * Heading tag used to wrap the main label.
+			 *
+			 * label を囲む見出しタグ。情報階層の逆転を避けるため、親セクション（h2）の
+			 * 配下に置く子セクションで 'h3' などを指定して見出しレベルを下げる用途。
+			 *
+			 * 許容値: 'h2' / 'h3' / 'h4' / 'h5' / 'h6'
+			 * 上記以外が渡された場合は安全のため 'h2' にフォールバックする。
+			 *
+			 * @var string
+			 */
+			public $label_tag = 'h2';
 
 			/**
 			 * Sub title shown under the main label.
@@ -111,12 +139,27 @@ if ( ! function_exists( 'vk_admin_register_custom_html_control' ) ) {
 			 * ラベル → サブタイトル → 任意 HTML の順で出力する。
 			 * いずれも未設定の場合は何も出力しない。
 			 *
+			 * label は $label_tag で指定された見出しタグ（デフォルト h2）で出力する。
+			 * 許容外の値が指定された場合は安全のため h2 にフォールバックする。
+			 *
 			 * @return void
 			 */
 			public function render_content() {
-				// ラベルが設定されていれば h2 として出力する。
+				// ラベルが設定されていれば $label_tag で指定された見出しタグとして出力する。
 				if ( $this->label ) {
-					echo '<h2 class="admin-custom-h2">' . wp_kses_post( $this->label ) . '</h2>';
+					// 許容する見出しタグのリスト。h1 はカスタマイザーパネルのタイトル等と衝突しうるため含めない。
+					$allowed_tags = array( 'h2', 'h3', 'h4', 'h5', 'h6' );
+					// 入力を小文字化し、許容リストに含まれない場合は 'h2' にフォールバックする。
+					$label_tag = in_array( strtolower( (string) $this->label_tag ), $allowed_tags, true ) ? strtolower( (string) $this->label_tag ) : 'h2';
+					// CSS クラスはタグに対応する名前にする（'admin-custom-h2' / 'admin-custom-h3' / ...）。
+					// 'admin-custom-h2' は従来から存在するクラス名のため、デフォルト挙動の後方互換が維持される。
+					$label_class = 'admin-custom-' . $label_tag;
+					printf(
+						'<%1$s class="%2$s">%3$s</%1$s>',
+						esc_attr( $label_tag ),
+						esc_attr( $label_class ),
+						wp_kses_post( $this->label )
+					);
 				}
 				// サブタイトルが設定されていれば h3 として出力する。
 				if ( $this->custom_title_sub ) {


### PR DESCRIPTION
WordPressエンジニアの和田です。

## 概要

`VK_Custom_Html_Control` の label を囲む見出しタグを切り替えられるように `$label_tag` プロパティを追加しました。

## 背景

現状 `VK_Custom_Html_Control` の label は h2 固定で出力されます。たとえば ExUnit の「Page top button image」（親 h2）の子設定として「Image size」のような子セクションを表示したい場合、子側も h2 で出てしまい、情報階層が逆転（親と同階層の見出しが入れ子になる）してしまいます。

これを解消するため、label の見出しタグを指定可能にしました。

## 変更内容

### `src/VK_Custom_Html_Control.php`

- `$label_tag` プロパティを追加（default `'h2'`）
- `render_content()` で `$label_tag` を見て見出しタグを動的に出力
- 許容値は `'h2'` / `'h3'` / `'h4'` / `'h5'` / `'h6'`、それ以外は安全のため `'h2'` にフォールバック
- CSS クラスはタグに対応した `admin-custom-h2` / `admin-custom-h3` / `admin-custom-h4` / `admin-custom-h5` / `admin-custom-h6` を付与（`admin-custom-h2` は従来通り）
- 出力は `printf` + `esc_attr()` でタグ名・クラス名をエスケープ。label 本体は従来通り `wp_kses_post()`

### `README.md`

- `label_tag` の利用例とフォールバック仕様を追記
- Change log に `== 0.8.0 ==` セクションを追加（label_tag プロパティ追加 / 後方互換あり）

## 後方互換

- `label_tag` 未指定時は `'h2'` で従来通り `<h2 class=\"admin-custom-h2\">` を出力
- 既存利用箇所への影響なし

## 利用例

\`\`\`php
new VK_Custom_Html_Control(
    \$wp_customize,
    'setting_id',
    array(
        'label'       => 'Image size',
        'label_tag'   => 'h3', // 親の h2 配下の子セクション見出しとして h3 を使う
        'section'     => 'my_section',
        'custom_html' => '<p>...</p>',
    )
);
\`\`\`

## 動作確認

- [x] \`php -l src/VK_Custom_Html_Control.php\` PASS
- [ ] カスタマイザー画面で \`label_tag\` 未指定時に従来通り \`<h2 class=\"admin-custom-h2\">\` が出力されること
- [ ] \`label_tag => 'h3'\` で \`<h3 class=\"admin-custom-h3\">\` が出力されること
- [ ] 許容外の値（例: \`'div'\` や \`'h1'\`）を渡すと \`'h2'\` にフォールバックすること

## 補足

- composer.json のバージョンは本 PR では変更していません（リリース時に別途）
- `custom_title_sub` は引き続き h3 固定です（サブタイトル用途のため階層的な見出しではないという整理）
- 新しいタグ（`admin-custom-h3` 以降）のスタイル CSS は vk-admin 側では同梱しません。利用側プラグイン・テーマで必要に応じて用意する前提です

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **新機能**
  * ラベル要素の見出しタグ（h2〜h6）を柔軟に設定できるようになりました。デフォルトはh2で後方互換性を保ちます。無効な値は自動的にh2にフォールバックします。

* **ドキュメント**
  * 新機能の使用方法と設定オプションをドキュメントに追加しました。バージョン0.8.0の変更ログも更新されています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-admin/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->