### PR TITLE
[ 不具合修正 ] 設定画面タイトル出力のエスケープ漏れと、アセット更新がブラウザに反映されない不具合の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ VkAdmin::init();
 
 ## Change log
 
+== 0.8.1 ==
 [ Bug Fix ] Fixed admin CSS/JS not refreshing in the browser after an update because of a stale asset cache-busting version.
-
 [ Bug Fix ] Fixed the settings page left sidebar navigation being pushed off-screen and unreachable when admin notices appeared, by showing notices at the top of the page (main area) instead.
 
+== 0.8.0 ==
 [ Spec Change ] Remove `VK_Custom_Html_Control` and `VK_Custom_Text_Control` because the same classes are now provided by [vektor-inc/vk-helpers](https://github.com/vektor-inc/vk-helpers) 0.3.0+. Projects that pulled these classes from vk-admin must switch to `vektor-inc/vk-helpers ^0.3.0` (this is a breaking change).
 
 == 0.7.0 ==

--- a/README.md
+++ b/README.md
@@ -25,11 +25,10 @@ VkAdmin::init();
 
 ## Change log
 
-== 0.8.1 ==
 [ Bug Fix ] Fixed admin CSS/JS not refreshing in the browser after an update because of a stale asset cache-busting version.
+
 [ Bug Fix ] Fixed the settings page left sidebar navigation being pushed off-screen and unreachable when admin notices appeared, by showing notices at the top of the page (main area) instead.
 
-== 0.8.0 ==
 [ Spec Change ] Remove `VK_Custom_Html_Control` and `VK_Custom_Text_Control` because the same classes are now provided by [vektor-inc/vk-helpers](https://github.com/vektor-inc/vk-helpers) 0.3.0+. Projects that pulled these classes from vk-admin must switch to `vektor-inc/vk-helpers ^0.3.0` (this is a breaking change).
 
 == 0.7.0 ==

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ VkAdmin::init();
 
 ## Change log
 
+[ Bug Fix ] Fixed admin CSS/JS not refreshing in the browser after an update because of a stale asset cache-busting version.
+
 [ Bug Fix ] Fixed the settings page left sidebar navigation being pushed off-screen and unreachable when admin notices appeared, by showing notices at the top of the page (main area) instead.
 
 [ Spec Change ] Remove `VK_Custom_Html_Control` and `VK_Custom_Text_Control` because the same classes are now provided by [vektor-inc/vk-helpers](https://github.com/vektor-inc/vk-helpers) 0.3.0+. Projects that pulled these classes from vk-admin must switch to `vektor-inc/vk-helpers ^0.3.0` (this is a breaking change).

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ VkAdmin::init();
 
 [ Bug Fix ] Fixed the settings page left sidebar navigation being pushed off-screen and unreachable when admin notices appeared, by showing notices at the top of the page (main area) instead.
 
+== 0.8.0 ==
 [ Spec Change ] Remove `VK_Custom_Html_Control` and `VK_Custom_Text_Control` because the same classes are now provided by [vektor-inc/vk-helpers](https://github.com/vektor-inc/vk-helpers) 0.3.0+. Projects that pulled these classes from vk-admin must switch to `vektor-inc/vk-helpers ^0.3.0` (this is a breaking change).
 
 == 0.7.0 ==

--- a/src/VkAdmin.php
+++ b/src/VkAdmin.php
@@ -5,14 +5,14 @@
  * @package vektor-inc/vk-admin
  * @license GPL-2.0+
  *
- * @version 0.8.1
+ * @version 0.5.1
  */
 
 namespace VektorInc\VK_Admin;
 
 class VkAdmin {
 
-	public static $version = '0.8.1';
+	public static $version = '0.5.1';
 
 	public static function init() {
 		$locale = ( is_admin() && function_exists( 'get_user_locale' ) ) ? get_user_locale() : get_locale();

--- a/src/VkAdmin.php
+++ b/src/VkAdmin.php
@@ -5,14 +5,14 @@
  * @package vektor-inc/vk-admin
  * @license GPL-2.0+
  *
- * @version 0.5.1
+ * @version 0.8.1
  */
 
 namespace VektorInc\VK_Admin;
 
 class VkAdmin {
 
-	public static $version = '0.5.1';
+	public static $version = '0.8.1';
 
 	public static function init() {
 		$locale = ( is_admin() && function_exists( 'get_user_locale' ) ) ? get_user_locale() : get_locale();
@@ -428,7 +428,7 @@ class VkAdmin {
 			<?php if ( $get_layout == 'column_2' ) : ?>
 				<div class="pageLogo"><?php echo $get_logo_html; ?></div>
 				<?php if ( $get_page_title ) : ?>
-					<h1 class="page_title"><?php echo $get_page_title; ?></h1>
+					<h1 class="page_title"><?php echo wp_kses_post( $get_page_title ); ?></h1>
 				<?php endif; ?>
 			<?php endif; ?>
 
@@ -448,14 +448,14 @@ class VkAdmin {
 			<hr class="wp-header-end" />
 
 			<div class="adminLayout">
-				<div class="adminMain <?php echo $get_layout; ?>">
+				<div class="adminMain <?php echo esc_attr( $get_layout ); ?>">
 
 					<?php if ( $get_layout == 'column_3' ) : ?>
 						<div id="adminContent_sub" class="scrTracking adminMain_sub">
 							<div class="adminMain_sub_inner">
 								<div class="pageLogo"><?php echo $get_logo_html; ?></div>
 								<?php if ( $get_page_title ) : ?>
-								<h2 class="page_title"><?php echo $get_page_title; ?></h2>
+								<h2 class="page_title"><?php echo wp_kses_post( $get_page_title ); ?></h2>
 								<?php endif; ?>
 								<div class="vk_option_nav">
 									<ul>
@@ -479,4 +479,3 @@ class VkAdmin {
 		<?php
 	}
 }
-


### PR DESCRIPTION
## チケットへのリンク / 変更の理由

- 関連Issue: #874（管理画面 設定ページのサイドナビが注意文で見切れる問題。根本対応は PR #18 でマージ済み）
- 関連Issue: #19（ロゴ・ナビゲーションHTML出力のサニタイズの残課題。本PRのレビュー過程で切り出し）

vk-admin（複数プラグインに同梱される共通ライブラリ）のリリース前ハードニングです。共通フレーム `admin_page_frame()` 周辺で見つかった小さな2点を、次のリリース（タグ 0.8.1 予定）に同梱するために対応します。

## どういう変更をしたか？

* 設定画面タイトルの出力（`admin_page_frame()` の h1 / h2）を生出力から `wp_kses_post()` に変更。エスケープ漏れ（出力境界の未サニタイズ）を塞ぎつつ、消費プラグインが意図的に渡す `<br>` などの正当なマークアップは保持。
* レイアウト用クラス名の出力（adminMain のクラス）を `esc_attr()` でエスケープ。
* アセットのキャッシュ更新（cache busting）に使う内部バージョン `$version` が 0.5.1 のまま古い値で固定されていたのを是正。これにより管理画面の CSS / JS の更新が利用者のブラウザに反映されるようになる。

補足：なぜ `wp_kses_post()` で `esc_html()` ではないか —— `esc_html()` だとタイトルに `<br>`（2行表示）を意図的に入れている消費プラグイン（Lightning G3 Pro Unit）で改行が消え、文字列「&lt;br&gt;」がそのまま画面表示される退行が起きるため。staff レビュー（安藤=セキュリティ／植草=UX）で `wp_kses_post()` に決定しました。

なお、これは vk-admin 単体の修正です。実利用者のブラウザに届くには、各消費プラグイン側が本ライブラリ（0.8.1）を取り込んで再リリースする必要があります。

### 既存ユーザーへの影響

* タイトル・ナビの**表示は変わりません**。`<br>` を含む Lightning G3 Pro Unit でも `wp_kses_post()` で改行が保持されるため、全消費プラグイン（vk-block-patterns / vk-all-in-one-expansion-unit / vk-blocks-pro / vk-link-target-controller / vk-post-author-display / lightning-g3-pro-unit）で出力は従来どおり。
* アセットバージョン是正により、ライブラリ更新後に管理画面の CSS/JS が確実に再取得されるようになります（これまでは古いキャッシュ版が残り得ました）。

### リリース時の注意（メンテナ向け）

* `$version` を 0.8.1 にハードコードしています。**実際に切るリリースタグも必ず 0.8.1** にしてください（タグと内部バージョンがズレると cache busting が再び効かなくなります）。

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] 本当にちゃんと確認をしたか？

※ 本PRは「タイトル/クラスのサニタイズ」と「アセットバージョン同期」の小さな2点を、いずれも `admin_page_frame()` 周辺・同一リリース前ハードニングとしてまとめています。意図が大きく異なる変更の混在ではない認識ですが、分割した方がよければご指摘ください。

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

※ 変更箇所は管理画面のマークアップを出力するメソッド（`admin_page_frame()`）と enqueue 用バージョン定数で、単体テストになじまない実装です。また当リポジトリにテスト基盤が無いため、本PRではテスト追加を見送り、確認手順で代替します。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

* `php -l src/VkAdmin.php` で構文エラーが無いことを確認。
* `git diff --check` で空白エラーが無いことを確認。
* 変更が `src/VkAdmin.php`（タイトル出力 wp_kses_post 化・クラス esc_attr 化・`$version` 0.8.1）と `README.md`（changelog 追記）の2ファイルのみであることを確認。
* 全6消費プラグインがタイトルに渡している文字列を確認し、`<br>` を含むのは Lightning G3 Pro Unit のみ・他はプレーンテキストであることを一次確認（`wp_kses_post()` で全プラグイン表示維持）。

## 確認URL

（なし。各消費プラグインの設定画面で確認可能）

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

### A. タイトル出力のサニタイズ（既存表示の維持）

1. vk-admin を取り込んだプラグインの設定画面を開く（例: Lightning G3 Pro Unit の設定画面）。
2. ページ見出し（タイトル）を見る。
   → Lightning G3 Pro Unit では「Lightning G3」と「Pro Unit」が **2行で表示**される（`<br>` が保持されている）。「&lt;br&gt;」という文字列がそのまま出ていないこと。
3. 他プラグイン（vk-block-patterns / VK Blocks など）の設定画面でも、タイトルが従来どおり表示されること。

### B. アセットのキャッシュ更新（cache busting）

1. 管理画面で vk-admin の CSS/JS（`vk_admin.css` など）の読み込み URL を確認する（ページのソース表示、または開発者ツールのネットワークタブ）。
   → クエリが `?ver=0.8.1` になっていること（修正前は `?ver=0.5.1` で固定だった）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- アップデート後に管理画面の CSS/JS がブラウザキャッシュで反映されない不具合を修正しました（古いキャッシュバスティング用バージョンに起因）。
- 管理画面通知表示時に左サイドバーが押し出され、到達不能になる不具合を修正しました。

## Security Improvements
- 管理画面のページタイトル表示およびレイアウト出力の安全性を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->